### PR TITLE
Improving creep efficiency on bringing energy to the room controller

### DIFF
--- a/section2/role.upgrader.js
+++ b/section2/role.upgrader.js
@@ -2,7 +2,7 @@ var roleUpgrader = {
 
     /** @param {Creep} creep **/
     run: function(creep) {
-        if(creep.store[RESOURCE_ENERGY] == 0) {
+        if(creep.store[RESOURCE_ENERGY] < 50) {
             var sources = creep.room.find(FIND_SOURCES);
             if(creep.harvest(sources[0]) == ERR_NOT_IN_RANGE) {
                 creep.moveTo(sources[0]);


### PR DESCRIPTION
I couldn't notice that if you apply the code of the creep harvesting energy only when the energy carried is 0, it would barely get any energy at all, now, I understand that it is a tutorial, but I believe this code would be better. 